### PR TITLE
Documentation improvements: fix badges, typo, and enhance examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 
-[![CI](https://github.com/avik-pal/MaybeInplace.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/avik-pal/MaybeInplace.jl/actions/workflows/CI.yml)
-[![codecov](https://codecov.io/gh/avik-pal/MaybeInplace.jl/branch/main/graph/badge.svg?)](https://codecov.io/gh/avik-pal/MaybeInplace.jl)
+[![CI](https://github.com/SciML/MaybeInplace.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/SciML/MaybeInplace.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/SciML/MaybeInplace.jl/branch/main/graph/badge.svg?)](https://codecov.io/gh/SciML/MaybeInplace.jl)
 [![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/MaybeInplace)](https://pkgs.genieframework.com?packages=MaybeInplace)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
-MaybeInplace.jl does a simple thing: If you write a code for mutable arrays, that won't work for immutable arrays. This package provides a macro `@bb` or `@bangbang` that will automatically convert the code to make it work for immutable arrays as well.
+MaybeInplace.jl solves a common problem in Julia: code written for mutable arrays often fails when used with immutable arrays (like StaticArrays). This package provides macros (`@bb`, `@bangbang`, or `@❗`) that automatically rewrite operations to work with both mutable and immutable arrays, choosing in-place operations when possible and out-of-place operations when necessary.
 
 ## Installation
 
@@ -29,20 +29,66 @@ MaybeInplace is a &nbsp;
 pkg> add MaybeInplace
 ```
 
-## How This Works?
+## Quick Example
 
-The code is simple enough to be self-explanatory. The basic idea is as follows, if you have the following code:
+```julia
+using MaybeInplace, StaticArrays
+
+# Without @bb: This function only works with mutable arrays
+function add_arrays!(result, a, b)
+    result .= a .+ b
+    return result
+end
+
+# Works with regular arrays
+add_arrays!([0.0, 0.0], [1.0, 2.0], [3.0, 4.0])  # ✓ Works
+
+# Fails with StaticArrays (immutable)
+# add_arrays!(@SVector[0.0, 0.0], @SVector[1.0, 2.0], @SVector[3.0, 4.0])  # ✗ Error!
+
+# With @bb: This function works with both mutable and immutable arrays
+function add_arrays_generic!(result, a, b)
+    @bb result .= a .+ b
+    return result
+end
+
+# Works with regular arrays (uses in-place operation)
+add_arrays_generic!([0.0, 0.0], [1.0, 2.0], [3.0, 4.0])  # ✓ Returns [4.0, 6.0]
+
+# Also works with StaticArrays (uses out-of-place operation)
+add_arrays_generic!(@SVector[0.0, 0.0], @SVector[1.0, 2.0], @SVector[3.0, 4.0])  # ✓ Returns @SVector[4.0, 6.0]
+```
+
+## How It Works
+
+The `@bb` macro inspects the array at runtime and chooses the appropriate operation. For example:
 
 ```julia
 @bb @. x = y + z
 ```
 
-This macro will convert it to:
+becomes:
 
 ```julia
 if setindex_trait(x) === CanSetindex()
-    @. x = y + z
+    @. x = y + z  # In-place for mutable arrays
 else
-    x = @. y + z
+    x = @. y + z  # Out-of-place for immutable arrays
 end
 ```
+
+## Supported Operations
+
+The macro supports the following operations:
+
+1. `copyto!(y, x)` - Copy operations
+2. `x .= <expr>` - Broadcasting assignment
+3. `@. <expr>` - Broadcast macro
+4. `x .+= <expr>`, `x .-= <expr>`, `x .*= <expr>`, `x ./= <expr>` - Compound assignment operators
+5. `x = copy(y)` - Copy with assignment
+6. `x = similar(y)` - Similar array creation
+7. `x = zero(y)` - Zero initialization
+8. `axpy!(a, x, y)` - BLAS-style operations
+9. `x = y × z` - Custom matrix multiplication operator (typed with `\times<tab>`)
+
+For a complete list and detailed examples, see the docstring: `?@bb`

--- a/src/MaybeInplace.jl
+++ b/src/MaybeInplace.jl
@@ -267,7 +267,7 @@ used by `@bangbang` to determine if an array can be setindex-ed or not.
 @inline setindex_trait(::Array) = CanSetindex()
 @inline setindex_trait(A::SubArray) = setindex_trait(parent(A))
 # In recent versions of Julia, this function has a type stable return type even without
-# overloading for sutom array types
+# overloading for custom array types
 @inline setindex_trait(A) = ifelse(can_setindex(A), CanSetindex(), CannotSetindex())
 
 ## Operations


### PR DESCRIPTION
## Summary

This PR improves the documentation quality for MaybeInplace.jl with several focused enhancements:

- **Fixed badge URLs**: Updated CI and codecov badges to point to the SciML organization instead of avik-pal
- **Fixed typo**: Corrected 'sutom' → 'custom' in the `setindex_trait` docstring (line 270)
- **Enhanced README introduction**: Rewrote the package description to more clearly explain what problem it solves
- **Added comprehensive Quick Example section**: Shows side-by-side comparison of code with and without `@bb`, demonstrating both mutable and immutable array usage
- **Improved "How It Works" section**: Added clearer explanation with inline comments
- **Added "Supported Operations" section**: Lists all 9 supported operations with brief descriptions

## Testing

All new code examples were tested to ensure they work correctly with both regular arrays and StaticArrays.

## Rationale

These changes make the documentation more accessible to new users by:
1. Providing concrete, runnable examples immediately
2. Clearly showing the before/after comparison
3. Listing all available operations in one place

@ChrisRackauckas - Please review these documentation improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)