### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,3 @@ updates:
       all-julia-packages:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,26 @@
+name: Downgrade
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-'
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -6,52 +6,17 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+  downstream:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SimpleNonlinearSolve.jl, group: All}
           - {user: SciML, repo: NonlinearSolve.jl, group: All}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-        env:
-          RETESTITEMS_NWORKERS: 4
-          RETESTITEMS_NWORKER_THREADS: 2
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,8 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  spellcheck:
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts all CI to the SciML centralized reusable workflows (pinned `@v1`), with `secrets: "inherit"` on every caller.

## Converted (inline -> central)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **Downstream.yml**: inline `IntegrationTest` job -> matrix of `downstream.yml@v1` callers, preserving the package+group list (SimpleNonlinearSolve.jl/All, NonlinearSolve.jl/All)

## Added (new central callers)
- **SpellCheck.yml**: `spellcheck.yml@v1` (every repo gets spellcheck)
- **Downgrade.yml**: `downgrade.yml@v1` (`julia-version: lts`, `skip: Pkg,TOML`)

## Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"`; preserved exactly (os matrix: ubuntu/macOS/windows).
- **TagBot.yml**: left as-is.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` ignore block; `github-actions` (weekly, `/`) and `julia` (daily, group `all-julia-packages: ["*"]`, dirs `/`, `/test`) blocks preserved.

## Checks
- Typos: ran `typos -w .` then `typos .` -> clean (exit 0), 0 fixes needed.
- Runic: ran `Runic.main(["--inplace","."])` -> no changes (repo was already Runic-clean from the inline check).
- No `docs/` directory, so no Documentation caller is added.
- No CompatHelper.yml present.

## Warning
Check names change (e.g. the Runic and downstream job names now come from the reusable workflows). Branch-protection required-status-check names will need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)