### PR TITLE
Use SciMLTesting v1.0.0 (run_tests harness)

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,9 @@
 [deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+SciMLTesting = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,11 @@
-using Pkg
 using SafeTestsets, Test
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "QA"
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.develop(PackageSpec(; path = joinpath(@__DIR__, "..")))
-    Pkg.instantiate()
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-else
-    @testset "MaybeInplace.jl" begin
-        if GROUP == "All" || GROUP == "Core"
-            @safetestset "Core" begin
-                include("basictests.jl")
-            end
-        end
-    end
-end
+run_tests(;
+    core = joinpath(@__DIR__, "basictests.jl"),
+    groups = Dict(
+        "QA" => (; env = joinpath(@__DIR__, "qa"), body = () -> begin
+            include(joinpath(@__DIR__, "qa", "qa.jl"))
+        end),
+    ),
+)


### PR DESCRIPTION
Replaces the hand-written `GROUP`-dispatch in `test/runtests.jl` with a single `SciMLTesting.run_tests(...)` call (SciMLTesting v1.0.0).

## Shape
Single-package with a standalone `test/Project.toml` env (no `[extras]`/`[targets]` in the main Project.toml). `GROUP`-dispatched, QA in an isolated `test/qa` sub-env, default `GROUP="All"`.

## Mapping (behavior-equivalent)
- `core = test/basictests.jl` (the original `Core`/`All` body; the file is self-contained with its own `using MaybeInplace, StaticArrays, Test, SparseArrays`).
- `QA` = `groups["QA"]` with a declared `env = test/qa`, so it is **not** run under `"All"` and is selectable only via `GROUP="QA"`, matching the original `if GROUP == "QA"`. The QA body (`Aqua.test_all(...; ambiguities=false)` + `JET.test_package(...; target_defined_modules=true)`) is kept verbatim via `include`.

Routing verified: unset→core, All→core, Core→core, QA→qa.

**Local verification:** ran the converted harness with `GROUP=Core` on Julia 1.11 — all `basictests.jl` testsets pass (copyto!, (_/+/-/*/div)=, dot, matmul, similar, setindex_trait).

## test/Project.toml
- `[deps]`: add `SciMLTesting` (UUID `09d9d899-...`), drop `Pkg` (only the old harness used it; SciMLTesting bundles Pkg). Add `[compat] SciMLTesting = "1"`. SciMLTesting is not added to `test/qa/Project.toml` (it stays loaded after `using SciMLTesting` when the qa env is activated).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)