### PR TITLE
Canonicalize tests: per-unit @safetestset isolation

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,3 +4,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+SafeTestsets = "0.1, 1"

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -1,137 +1,25 @@
-using MaybeInplace, StaticArrays, Test, SparseArrays
-using MaybeInplace: LinearAlgebra
+using SafeTestsets
 
-function copyto!!(y, x)
-    @bb copyto!(y, x)
-    return y
+@safetestset "copyto!" begin
+    include("copyto.jl")
 end
 
-function eqop!!(y, x1, x2, x3, x4, x5)
-    @bb y .= x1
-    @bb y .+= x2
-    @bb y .*= x3
-    @bb y .-= x4
-    @bb y ./= x5
-    return y
+@safetestset "(_/+/-/*/div)=" begin
+    include("eqop.jl")
 end
 
-function dotmacro!!(y, x, z)
-    @bb @. y = x * z
-    return y
+@safetestset "dot" begin
+    include("dot.jl")
 end
 
-function matmul!!(y, x, z)
-    @bb y = x × z
-    return y
+@safetestset "matmul" begin
+    include("matmul.jl")
 end
 
-function get_similar(x)
-    @bb z = similar(x)
-    return z
+@safetestset "similar" begin
+    include("similar.jl")
 end
 
-@testset "copyto!" begin
-    x = [1.0, 1.0]
-    y = [0.0, 0.0]
-    @test copyto!!(y, x) == [1.0, 1.0]
-    @test y == [1.0, 1.0]
-
-    x = @SVector[1.0, 1.0]
-    y = @SVector[0.0, 0.0]
-    @test copyto!!(y, x) == @SVector[1.0, 1.0]
-    @test y == @SVector[0.0, 0.0]
-
-    x = @SMatrix[1.0 1.0; 1.0 1.0]
-    y = @SMatrix[0.0 0.0; 0.0 0.0]
-    @test copyto!!(y, x) == @SMatrix[1.0 1.0; 1.0 1.0]
-    @test y == @SMatrix[0.0 0.0; 0.0 0.0]
-end
-
-@testset "(_/+/-/*/div)=" begin
-    y = [0.0, 0.0]
-    x1 = [1.0, 1.0]
-    x2 = [1.0, 1.0]
-    x3 = [1.0, 1.0]
-    x4 = [1.0, 1.0]
-    x5 = [1.0, 1.0]
-    @test eqop!!(y, x1, x2, x3, x4, x5) == [1.0, 1.0]
-    @test y == [1.0, 1.0]
-
-    y = @SVector[0.0, 0.0]
-    x1 = @SVector[1.0, 1.0]
-    x2 = @SVector[1.0, 1.0]
-    x3 = @SVector[1.0, 1.0]
-    x4 = @SVector[1.0, 1.0]
-    x5 = @SVector[1.0, 1.0]
-    @test eqop!!(y, x1, x2, x3, x4, x5) == @SVector[1.0, 1.0]
-    @test y == @SVector[0.0, 0.0]
-end
-
-@testset "dot" begin
-    y = [0.0, 0.0]
-    x = [1.0, 1.0]
-    z = [1.0, 1.0]
-    @test dotmacro!!(y, x, z) == [1.0, 1.0]
-    @test y == [1.0, 1.0]
-
-    y = @SVector[0.0, 0.0]
-    x = @SVector[1.0, 1.0]
-    z = @SVector[1.0, 1.0]
-    @test dotmacro!!(y, x, z) == @SVector[1.0, 1.0]
-    @test y == @SVector[0.0, 0.0]
-end
-
-@testset "matmul" begin
-    y = [0.0, 0.0]
-    x = [1.0 1.0; 1.0 1.0]
-    z = [1.0, 1.0]
-    @test matmul!!(y, x, z) == [2.0, 2.0]
-    @test y == [2.0, 2.0]
-
-    y = @SVector[0.0, 0.0]
-    x = @SMatrix[1.0 1.0; 1.0 1.0]
-    z = @SVector[1.0, 1.0]
-    @test matmul!!(y, x, z) == @SVector[2.0, 2.0]
-    @test y == @SVector[0.0, 0.0]
-
-    x = sprand(100, 100, 0.01)
-    z = sprand(100, 100, 0.01)
-    y = x * z
-    @test matmul!!(y, x, z) == x * z
-end
-
-@testset "similar" begin
-    x = [1.0, 1.0]
-    z = get_similar(x)
-
-    @test_nowarn z[1]
-
-    x = BigFloat[1.0, 1.0]
-    z = get_similar(x)
-
-    @test_nowarn z[1]  # Without correct similar this would throw UndefRefError
-end
-
-@testset "setindex_trait with LinearAlgebra wrappers" begin
-    # Test with mutable arrays (should be CanSetindex)
-    A = [1.0 2.0; 2.0 3.0]
-    v = [1.0, 2.0]
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Symmetric(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Hermitian(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UpperTriangular(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.LowerTriangular(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitUpperTriangular(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitLowerTriangular(A)) == MaybeInplace.CanSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Diagonal(v)) == MaybeInplace.CanSetindex()
-
-    # Test with immutable arrays (should be CannotSetindex)
-    SA_mat = SA[1.0 2.0; 2.0 3.0]
-    SA_vec = SA[1.0, 2.0]
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Symmetric(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Hermitian(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UpperTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.LowerTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitUpperTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitLowerTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
-    @test MaybeInplace.setindex_trait(LinearAlgebra.Diagonal(SA_vec)) == MaybeInplace.CannotSetindex()
+@safetestset "setindex_trait with LinearAlgebra wrappers" begin
+    include("setindex_trait.jl")
 end

--- a/test/basictests_setup.jl
+++ b/test/basictests_setup.jl
@@ -1,0 +1,30 @@
+using MaybeInplace
+
+function copyto!!(y, x)
+    @bb copyto!(y, x)
+    return y
+end
+
+function eqop!!(y, x1, x2, x3, x4, x5)
+    @bb y .= x1
+    @bb y .+= x2
+    @bb y .*= x3
+    @bb y .-= x4
+    @bb y ./= x5
+    return y
+end
+
+function dotmacro!!(y, x, z)
+    @bb @. y = x * z
+    return y
+end
+
+function matmul!!(y, x, z)
+    @bb y = x × z
+    return y
+end
+
+function get_similar(x)
+    @bb z = similar(x)
+    return z
+end

--- a/test/copyto.jl
+++ b/test/copyto.jl
@@ -1,0 +1,19 @@
+using MaybeInplace, StaticArrays, Test
+include("basictests_setup.jl")
+
+@testset "copyto!" begin
+    x = [1.0, 1.0]
+    y = [0.0, 0.0]
+    @test copyto!!(y, x) == [1.0, 1.0]
+    @test y == [1.0, 1.0]
+
+    x = @SVector[1.0, 1.0]
+    y = @SVector[0.0, 0.0]
+    @test copyto!!(y, x) == @SVector[1.0, 1.0]
+    @test y == @SVector[0.0, 0.0]
+
+    x = @SMatrix[1.0 1.0; 1.0 1.0]
+    y = @SMatrix[0.0 0.0; 0.0 0.0]
+    @test copyto!!(y, x) == @SMatrix[1.0 1.0; 1.0 1.0]
+    @test y == @SMatrix[0.0 0.0; 0.0 0.0]
+end

--- a/test/dot.jl
+++ b/test/dot.jl
@@ -1,0 +1,16 @@
+using MaybeInplace, StaticArrays, Test
+include("basictests_setup.jl")
+
+@testset "dot" begin
+    y = [0.0, 0.0]
+    x = [1.0, 1.0]
+    z = [1.0, 1.0]
+    @test dotmacro!!(y, x, z) == [1.0, 1.0]
+    @test y == [1.0, 1.0]
+
+    y = @SVector[0.0, 0.0]
+    x = @SVector[1.0, 1.0]
+    z = @SVector[1.0, 1.0]
+    @test dotmacro!!(y, x, z) == @SVector[1.0, 1.0]
+    @test y == @SVector[0.0, 0.0]
+end

--- a/test/eqop.jl
+++ b/test/eqop.jl
@@ -1,0 +1,22 @@
+using MaybeInplace, StaticArrays, Test
+include("basictests_setup.jl")
+
+@testset "(_/+/-/*/div)=" begin
+    y = [0.0, 0.0]
+    x1 = [1.0, 1.0]
+    x2 = [1.0, 1.0]
+    x3 = [1.0, 1.0]
+    x4 = [1.0, 1.0]
+    x5 = [1.0, 1.0]
+    @test eqop!!(y, x1, x2, x3, x4, x5) == [1.0, 1.0]
+    @test y == [1.0, 1.0]
+
+    y = @SVector[0.0, 0.0]
+    x1 = @SVector[1.0, 1.0]
+    x2 = @SVector[1.0, 1.0]
+    x3 = @SVector[1.0, 1.0]
+    x4 = @SVector[1.0, 1.0]
+    x5 = @SVector[1.0, 1.0]
+    @test eqop!!(y, x1, x2, x3, x4, x5) == @SVector[1.0, 1.0]
+    @test y == @SVector[0.0, 0.0]
+end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1,0 +1,21 @@
+using MaybeInplace, StaticArrays, SparseArrays, Test
+include("basictests_setup.jl")
+
+@testset "matmul" begin
+    y = [0.0, 0.0]
+    x = [1.0 1.0; 1.0 1.0]
+    z = [1.0, 1.0]
+    @test matmul!!(y, x, z) == [2.0, 2.0]
+    @test y == [2.0, 2.0]
+
+    y = @SVector[0.0, 0.0]
+    x = @SMatrix[1.0 1.0; 1.0 1.0]
+    z = @SVector[1.0, 1.0]
+    @test matmul!!(y, x, z) == @SVector[2.0, 2.0]
+    @test y == @SVector[0.0, 0.0]
+
+    x = sprand(100, 100, 0.01)
+    z = sprand(100, 100, 0.01)
+    y = x * z
+    @test matmul!!(y, x, z) == x * z
+end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,10 +2,12 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MaybeInplace = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 MaybeInplace = { path = "../.." }
 
 [compat]
+SafeTestsets = "0.1, 1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,11 @@
-using Aqua, JET, MaybeInplace, Test
+using SafeTestsets
 
-@testset "Code quality (Aqua.jl)" begin
+@safetestset "Code quality (Aqua.jl)" begin
+    using Aqua, MaybeInplace
     Aqua.test_all(MaybeInplace; ambiguities = false)
 end
 
-@testset "Code linting (JET.jl)" begin
+@safetestset "Code linting (JET.jl)" begin
+    using JET, MaybeInplace
     JET.test_package(MaybeInplace; target_defined_modules = true)
 end

--- a/test/setindex_trait.jl
+++ b/test/setindex_trait.jl
@@ -1,0 +1,26 @@
+using MaybeInplace, StaticArrays, Test
+using MaybeInplace: LinearAlgebra
+
+@testset "setindex_trait with LinearAlgebra wrappers" begin
+    # Test with mutable arrays (should be CanSetindex)
+    A = [1.0 2.0; 2.0 3.0]
+    v = [1.0, 2.0]
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Symmetric(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Hermitian(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UpperTriangular(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.LowerTriangular(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitUpperTriangular(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitLowerTriangular(A)) == MaybeInplace.CanSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Diagonal(v)) == MaybeInplace.CanSetindex()
+
+    # Test with immutable arrays (should be CannotSetindex)
+    SA_mat = SA[1.0 2.0; 2.0 3.0]
+    SA_vec = SA[1.0, 2.0]
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Symmetric(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Hermitian(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UpperTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.LowerTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitUpperTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.UnitLowerTriangular(SA_mat)) == MaybeInplace.CannotSetindex()
+    @test MaybeInplace.setindex_trait(LinearAlgebra.Diagonal(SA_vec)) == MaybeInplace.CannotSetindex()
+end

--- a/test/similar.jl
+++ b/test/similar.jl
@@ -1,0 +1,14 @@
+using MaybeInplace, Test
+include("basictests_setup.jl")
+
+@testset "similar" begin
+    x = [1.0, 1.0]
+    z = get_similar(x)
+
+    @test_nowarn z[1]
+
+    x = BigFloat[1.0, 1.0]
+    z = get_similar(x)
+
+    @test_nowarn z[1]  # Without correct similar this would throw UndefRefError
+end


### PR DESCRIPTION
## Summary

Canonicalizes the test suite so each independent test unit runs in its own module via `@safetestset`, matching the OrdinaryDiffEq canonical structure (isolation between tests + world-age safety).

Previously `test/basictests.jl` ran as a single `@safetestset "Core"` module containing 6 plain `@testset` blocks that shared module-level `@bb` helper functions — so the 6 units were not isolated from one another. This PR turns each `@testset` into its own `@safetestset`.

## Changes

- `test/basictests.jl` becomes a thin dispatcher of `@safetestset "X" begin include("x.jl") end` (one per unit: copyto!, eqop, dot, matmul, similar, setindex_trait).
- Shared `@bb` helper functions moved to new `test/basictests_setup.jl`, which each unit file `include`s.
- Each new unit file (`copyto.jl`, `eqop.jl`, `dot.jl`, `matmul.jl`, `similar.jl`, `setindex_trait.jl`) carries its own `using` lines.
- The `include()` form is required: the unit bodies use the `@bb` package macro and StaticArrays macros, and `include()` evaluates top-level statements one at a time so `using MaybeInplace`/`using StaticArrays` run before the macros are parsed.
- `test/qa/qa.jl`: the two QA units (Aqua, JET) become `@safetestset`, each with its own `using`.
- `SafeTestsets` compat added to `test/Project.toml`; `SafeTestsets` (dep + compat) added to `test/qa/Project.toml` since the QA group activates its own project.

No change to the GROUP-dispatch ladder, the run path, or any assertion. Same tests run, same assertions.

## Verification

Verified locally with Julia 1.11:
- `GROUP=Core Pkg.test()` -> `MaybeInplace.jl | 35 35 pass`
- `GROUP=QA Pkg.test()` -> `Code quality (Aqua.jl) | 10 10 pass`, `Code linting (JET.jl) | 1 1 pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.