### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MaybeInplace"
 uuid = "bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Automated patch version bump (0.1.5 -> 0.1.6) to release unreleased commits on `main` via JuliaRegistrator.